### PR TITLE
Fix parameter encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 1.0.5
+- Fixed parameter encoding
+
+## 1.0.5
 - Allow `oauth_callback_confirmed=1` in addition to `oauth_callback_confirmed=true`
 - Add example
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.5
+## 1.0.6
 - Fixed parameter encoding
 
 ## 1.0.5

--- a/lib/src/authorization_header.dart
+++ b/lib/src/authorization_header.dart
@@ -1,10 +1,10 @@
 library authorization_header;
 
+import 'client_credentials.dart';
+import 'credentials.dart';
 // import 'package:uuid/uuid.dart';
 
 import 'signature_method.dart';
-import 'client_credentials.dart';
-import 'credentials.dart';
 
 /// A class describing Authorization Header.
 /// http://tools.ietf.org/html/rfc5849#section-3.5.1
@@ -60,6 +60,15 @@ class AuthorizationHeader {
     return authHeader;
   }
 
+  String _encodeParam(String param) {
+    return Uri.encodeComponent(param)
+        .replaceAll('!', '%21')
+        .replaceAll('*', '%2A')
+        .replaceAll("'", '%27')
+        .replaceAll('(', '%28')
+        .replaceAll(')', '%29');
+  }
+
   /// Create signature in ways referred from
   /// https://dev.twitter.com/docs/auth/creating-signature.
   String _createSignature(
@@ -78,10 +87,10 @@ class AuthorizationHeader {
     //    that will be signed.
     final Map<String, String> encodedParams = <String, String>{};
     params.forEach((String k, String v) {
-      encodedParams[Uri.encodeComponent(k)] = Uri.encodeComponent(v);
+      encodedParams[_encodeParam(k)] = _encodeParam(v);
     });
     uri.queryParameters.forEach((String k, String v) {
-      encodedParams[Uri.encodeComponent(k)] = Uri.encodeComponent(v);
+      encodedParams[_encodeParam(k)] = _encodeParam(v);
     });
     params.remove('realm');
 

--- a/lib/src/authorization_header.dart
+++ b/lib/src/authorization_header.dart
@@ -60,6 +60,12 @@ class AuthorizationHeader {
     return authHeader;
   }
 
+  /// Percent-encodes the [param].
+  ///
+  /// All characters except uppercase and lowercase letters, digits and the
+  /// characters `-_.~`  are percent-encoded.
+  ///
+  /// See https://oauth.net/core/1.0a/#encoding_parameters.
   String _encodeParam(String param) {
     return Uri.encodeComponent(param)
         .replaceAll('!', '%21')

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: oauth1
-version: 1.0.5
+version: 1.0.6
 description: "\"RFC 5849: The OAuth 1.0 Protocol\" client implementation for Dart."
 homepage: https://github.com/nbspou/dart-oauth1
 author: kumar8600 <kumar1@hotmail.co.jp>


### PR DESCRIPTION
Hi @kaetemi,
there is an issue where some characters in the parameters don't get encoded properly, causing the oauth signature to be invalid.

This package uses the `Uri.encodeComponent(param)` to encode the params.
`Uri.encodeComponent(param)` encodes all characters except letters, numbers and `-_.!~*'()`.
However the oauth1.0a specs define all characters except letters, numbers and `-_.~` need to be percent-encoded (See https://oauth.net/core/1.0a/#encoding_parameters)

In this PR I simply replaced all occurrences of the characters that are not accounted for in `Uri.encodeComponent(param)` for with their percent encoded value.

I also added a changelog and raised the version number.