### PR TITLE
Change SignatureMethod to be asynchronous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.0
+- Change `SignatureMethod` to be asynchronous.
+
 ## 2.0.0
 - Migrate to null safety
 

--- a/lib/src/authorization.dart
+++ b/lib/src/authorization.dart
@@ -47,7 +47,7 @@ class Authorization {
 
     final http.Response res = await _httpClient.post(
         Uri.parse(_platform.temporaryCredentialsRequestURI),
-        headers: <String, String>{'Authorization': ahb.build().toString()});
+        headers: <String, String>{'Authorization': await ahb.build().encode()});
 
     if (res.statusCode != 200) {
       throw StateError(res.body);
@@ -88,7 +88,7 @@ class Authorization {
 
     final http.Response res = await _httpClient.post(
         Uri.parse(_platform.tokenCredentialsRequestURI),
-        headers: <String, String>{'Authorization': ahb.build().toString()});
+        headers: <String, String>{'Authorization': await ahb.build().encode()});
 
     if (res.statusCode != 200) {
       throw StateError(res.body);

--- a/lib/src/authorization_header.dart
+++ b/lib/src/authorization_header.dart
@@ -35,8 +35,7 @@ class AuthorizationHeader {
   ///
   /// You can add parameters by _authorizationHeader.
   /// (You can override too but I don't recommend.)
-  @override
-  String toString() {
+  Future<String> encode() async {
     final Map<String, String> params = <String, String>{};
 
     params['oauth_nonce'] = DateTime.now().millisecondsSinceEpoch.toString();
@@ -50,7 +49,7 @@ class AuthorizationHeader {
     }
     params.addAll(_additionalParameters!);
     if (!params.containsKey('oauth_signature')) {
-      params['oauth_signature'] = _createSignature(_method, _url, params);
+      params['oauth_signature'] = await _createSignature(_method, _url, params);
     }
 
     final String authHeader = 'OAuth ' +
@@ -77,7 +76,7 @@ class AuthorizationHeader {
 
   /// Create signature in ways referred from
   /// https://dev.twitter.com/docs/auth/creating-signature.
-  String _createSignature(
+  Future<String> _createSignature(
       String method, String url, Map<String, String> params) {
     // Referred from https://dev.twitter.com/docs/auth/creating-signature
     if (params.isEmpty) {

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -29,7 +29,7 @@ class Client extends http.BaseClient {
             httpClient != null ? httpClient : http.Client() as http.BaseClient;
 
   @override
-  Future<http.StreamedResponse> send(http.BaseRequest request) {
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
     final AuthorizationHeaderBuilder ahb = AuthorizationHeaderBuilder();
     ahb.signatureMethod = _signatureMethod;
     ahb.clientCredentials = _clientCredentials;
@@ -49,7 +49,7 @@ class Client extends http.BaseClient {
     }
     ahb.additionalParameters = additionalParameters;
 
-    request.headers['Authorization'] = ahb.build().toString();
-    return _httpClient.send(request);
+    request.headers['Authorization'] = await ahb.build().encode();
+    return await _httpClient.send(request);
   }
 }

--- a/lib/src/signature_method.dart
+++ b/lib/src/signature_method.dart
@@ -1,5 +1,6 @@
 library signature_method;
 
+import 'dart:async';
 import 'dart:convert';
 import 'package:crypto/crypto.dart';
 
@@ -7,7 +8,7 @@ import 'package:crypto/crypto.dart';
 /// http://tools.ietf.org/html/rfc5849#section-3.4
 class SignatureMethod {
   final String _name;
-  final String Function(String key, String text) _sign;
+  final FutureOr<String> Function(String key, String text) _sign;
 
   /// A constructor of SignatureMethod.
   SignatureMethod(this._name, this._sign);
@@ -16,7 +17,7 @@ class SignatureMethod {
   String get name => _name;
 
   /// Sign data by key.
-  String sign(String key, String text) => _sign(key, text);
+  Future<String> sign(String key, String text) async => await _sign(key, text);
 }
 
 /// A abstract class contains Signature Methods.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: oauth1
-version: 2.0.0
+version: 2.1.0
 description: "\"RFC 5849: The OAuth 1.0 Protocol\" client implementation for Dart."
 homepage: https://github.com/nbspou/dart-oauth1
 


### PR DESCRIPTION
This pull request change the signature of `SignatureMethod` callback to accept returning a `Future`

A lot of packages implements the crypto algorithms with an asynchronous API. I would like to implement the `RSA-SHA1` signature method with [`webcrypto`](https://pub.dev/packages/webcrypto) like this:

```dart
import 'package:webcrypto/webcrypto.dart';

void main() {
  final rsaSha1 = SignatureMethod('RSA-SHA1', (String key, String text) async {
    var privateKey =
        await RsassaPkcs1V15PrivateKey.importPkcs8Key(_privateKey, Hash.sha1);
    return base64Encode(await privateKey.signBytes(text.codeUnits));
  });
}
```
