### PR TITLE
Support for Dart 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.0
+- Support for newer Dart and `http` versions
+
 ## 2.0.0
 - Migrate to null safety
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add to `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  oauth1: ^1.0.6
+  oauth1: ^2.1.0
 ```
 
 Please use like below.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,3 +1,5 @@
+include: package:lints/recommended.yaml
+
 analyzer:
   errors:
     # treat missing required parameters as a warning (not a hint)
@@ -52,6 +54,7 @@ linter:
     - cancel_subscriptions
     # - cascade_invocations # not yet tested
     # - close_sinks # not reliable enough
+    - collection_methods_unrelated_type
     # - comment_references # blocked on https://github.com/flutter/flutter/issues/20765
     # - constant_identifier_names # needs an opt-out https://github.com/dart-lang/linter/issues/204
     - control_flow_in_finally
@@ -65,12 +68,10 @@ linter:
     - hash_and_equals
     - implementation_imports
     # - invariant_booleans # too many false positives: https://github.com/dart-lang/linter/issues/811
-    - iterable_contains_unrelated_type
     # - join_return_with_assignment # not yet tested
     - library_names
     - library_prefixes
     # - lines_longer_than_80_chars # not yet tested
-    - list_remove_unrelated_type
     # - literal_only_boolean_expressions # too many false positives: https://github.com/dart-lang/sdk/issues/34181
     - no_adjacent_strings_in_list
     - no_duplicate_case_values

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,6 +1,4 @@
 analyzer:
-  strong-mode:
-    implicit-dynamic: false
   errors:
     # treat missing required parameters as a warning (not a hint)
     missing_required_param: warning
@@ -17,7 +15,7 @@ linter:
     - always_declare_return_types
     - always_put_control_body_on_new_line
     # - always_put_required_named_parameters_first # we prefer having parameters in the same order as fields https://github.com/flutter/flutter/issues/10219
-    - always_require_non_null_named_parameters
+    # - always_require_non_null_named_parameters
     - always_specify_types
     - annotate_overrides
     # - avoid_annotating_with_dynamic # conflicts with always_specify_types
@@ -96,7 +94,7 @@ linter:
     - prefer_const_literals_to_create_immutables
     # - prefer_constructors_over_static_methods # not yet tested
     - prefer_contains
-    - prefer_equal_for_default_values
+    # - prefer_equal_for_default_values
     # - prefer_expression_function_bodies # conflicts with https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#consider-using--for-short-functions-and-methods
     - prefer_final_fields
     - prefer_final_locals

--- a/example/oauth1_example.dart
+++ b/example/oauth1_example.dart
@@ -51,6 +51,6 @@ void main() {
     });
 
     // NOTE: you can get optional values from AuthorizationResponse object
-    print('Your screen name is ' + res.optionalParameters['screen_name']!);
+    print('Your screen name is ${res.optionalParameters['screen_name']!}');
   });
 }

--- a/lib/src/authorization.dart
+++ b/lib/src/authorization.dart
@@ -66,9 +66,8 @@ class Authorization {
   /// http://tools.ietf.org/html/rfc5849#section-2.2
   String getResourceOwnerAuthorizationURI(
       String temporaryCredentialsIdentifier) {
-    return _platform.resourceOwnerAuthorizationURI +
-        '?oauth_token=' +
-        Uri.encodeComponent(temporaryCredentialsIdentifier);
+    return '${_platform.resourceOwnerAuthorizationURI}'
+        '?oauth_token=${Uri.encodeComponent(temporaryCredentialsIdentifier)}';
   }
 
   /// Obtain a set of token credentials from the server.

--- a/lib/src/authorization_header.dart
+++ b/lib/src/authorization_header.dart
@@ -53,10 +53,9 @@ class AuthorizationHeader {
       params['oauth_signature'] = _createSignature(_method, _url, params);
     }
 
-    final String authHeader = 'OAuth ' +
-        params.keys.map((String k) {
-          return '$k="${Uri.encodeComponent(params[k]!)}"';
-        }).join(', ');
+    final String authHeader = 'OAuth ${params.keys.map((String k) {
+      return '$k="${Uri.encodeComponent(params[k]!)}"';
+    }).join(', ')}';
     return authHeader;
   }
 

--- a/lib/src/authorization_header_builder.dart
+++ b/lib/src/authorization_header_builder.dart
@@ -25,7 +25,7 @@ class AuthorizationHeaderBuilder {
 
   set signatureMethod(SignatureMethod value) => _signatureMethod = value;
   set clientCredentials(ClientCredentials value) => _clientCredentials = value;
-  set credentials(Credentials value) => _credentials = value;
+  set credentials(Credentials? value) => _credentials = value;
   set method(String value) => _method = value;
   set url(String value) => _url = value;
   set additionalParameters(Map<String, String> value) =>

--- a/lib/src/authorization_response.dart
+++ b/lib/src/authorization_response.dart
@@ -2,7 +2,7 @@ library authorization_response;
 
 import 'credentials.dart';
 
-/// A class describing Response of Authoriazation request.
+/// A class describing Response of Authorization request.
 class AuthorizationResponse {
   final Credentials _credentials;
   final Map<String, String> _optionalParameters;

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -25,8 +25,7 @@ class Client extends http.BaseClient {
   /// https://api.dartlang.org/apidocs/channels/stable/dartdoc-viewer/http/http-browser_client.BrowserClient
   Client(this._signatureMethod, this._clientCredentials, this._credentials,
       [http.BaseClient? httpClient])
-      : _httpClient =
-            httpClient != null ? httpClient : http.Client() as http.BaseClient;
+      : _httpClient = httpClient ?? http.Client() as http.BaseClient;
 
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) {

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -16,7 +16,7 @@ import 'signature_method.dart';
 class Client extends http.BaseClient {
   final SignatureMethod _signatureMethod;
   final ClientCredentials _clientCredentials;
-  final Credentials _credentials;
+  final Credentials? _credentials;
   final http.BaseClient _httpClient;
 
   /// A constructor of Client.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,4 +11,5 @@ dependencies:
   http: '>=0.13.0 <2.0.0'
 
 dev_dependencies:
+  lints: ^3.0.0
   test: ^1.16.5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,6 +2,13 @@ name: oauth1
 version: 2.1.0
 description: "\"RFC 5849: The OAuth 1.0 Protocol\" client implementation for Dart."
 homepage: https://github.com/nbspou/dart-oauth1
+repository: https://github.com/nbspou/dart-oauth1
+issue_tracker: https://github.com/nbspou/dart-oauth1/issues
+topics:
+  - authentication
+  - network
+  - oauth
+  - web
 
 environment:
   sdk: '>=2.12.0 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,14 +1,14 @@
 name: oauth1
-version: 2.0.0
+version: 2.1.0
 description: "\"RFC 5849: The OAuth 1.0 Protocol\" client implementation for Dart."
 homepage: https://github.com/nbspou/dart-oauth1
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
 
 dependencies:
   crypto: ^3.0.0
-  http: ^0.13.0
+  http: '>=0.13.0 <2.0.0'
 
 dev_dependencies:
   test: ^1.16.5


### PR DESCRIPTION
This PR adds support for Dart 3, removes a few deprecated linter rules, fixes a small typo in documentation and allows `null`
 credentials again
Fixes #18
Fixes #19 